### PR TITLE
Add full text RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -10,10 +10,10 @@
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.description | xml_escape }}</description>
+        <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-	<link>https://blog.wesleyac.com{{ post.url }}</link>
-	<guid isPermaLink="true">https://blog.wesleyac.com{{ post.url }}</guid>
+        <link>https://blog.wesleyac.com{{ post.url }}</link>
+        <guid isPermaLink="true">https://blog.wesleyac.com{{ post.url }}</guid>
       </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
This PR adds a full-text RSS feed so that one can not only view the title of the post, but also the contents.

This...

![current RSS feed](https://user-images.githubusercontent.com/37990858/80910021-d13ff900-8d67-11ea-951a-58d47991c678.png)

becomes this after this change.

![full text RSS feed](https://user-images.githubusercontent.com/37990858/80910025-d604ad00-8d67-11ea-9f93-dff238ec34dd.png)
